### PR TITLE
Use size_t and fixed width format specifiers for printf()...  for siphash.c

### DIFF
--- a/siphash.c
+++ b/siphash.c
@@ -15,6 +15,7 @@
    <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 #include <assert.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -66,14 +67,10 @@
 #ifdef DEBUG
 #define TRACE                                                                  \
     do {                                                                       \
-        printf("(%3d) v0 %08x %08x\n", (int)inlen, (uint32_t)(v0 >> 32),       \
-               (uint32_t)v0);                                                  \
-        printf("(%3d) v1 %08x %08x\n", (int)inlen, (uint32_t)(v1 >> 32),       \
-               (uint32_t)v1);                                                  \
-        printf("(%3d) v2 %08x %08x\n", (int)inlen, (uint32_t)(v2 >> 32),       \
-               (uint32_t)v2);                                                  \
-        printf("(%3d) v3 %08x %08x\n", (int)inlen, (uint32_t)(v3 >> 32),       \
-               (uint32_t)v3);                                                  \
+        printf("(%3zu) v0 %016"PRIx64"\n", inlen, v0);                          \
+        printf("(%3zu) v1 %016"PRIx64"\n", inlen, v1);                          \
+        printf("(%3zu) v2 %016"PRIx64"\n", inlen, v2);                          \
+        printf("(%3zu) v3 %016"PRIx64"\n", inlen, v3);                          \
     } while (0)
 #else
 #define TRACE

--- a/siphash.c
+++ b/siphash.c
@@ -67,10 +67,10 @@
 #ifdef DEBUG
 #define TRACE                                                                  \
     do {                                                                       \
-        printf("(%3zu) v0 %016"PRIx64"\n", inlen, v0);                          \
-        printf("(%3zu) v1 %016"PRIx64"\n", inlen, v1);                          \
-        printf("(%3zu) v2 %016"PRIx64"\n", inlen, v2);                          \
-        printf("(%3zu) v3 %016"PRIx64"\n", inlen, v3);                          \
+        printf("(%3zu) v0 %016"PRIx64"\n", inlen, v0);                         \
+        printf("(%3zu) v1 %016"PRIx64"\n", inlen, v1);                         \
+        printf("(%3zu) v2 %016"PRIx64"\n", inlen, v2);                         \
+        printf("(%3zu) v3 %016"PRIx64"\n", inlen, v3);                         \
     } while (0)
 #else
 #define TRACE


### PR DESCRIPTION
It was forgotten in #17 to apply this to siphash.c as well as halfsiphash.c.  Note
that as-is this does change to a single 16-hex-char string for v0/1/2/3 in debug
output rather than having 8 then a space then 8.  If preferred it can be changed
back to having the space and using `PRIx32` twice instead of `PRIx64` once.