### PR TITLE
Return non-zero when tests fail

### DIFF
--- a/test.c
+++ b/test.c
@@ -13,6 +13,7 @@
  */
 
 #include "vectors.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -46,6 +47,7 @@ size_t lengths[4] = {8, 16, 4, 8};
 int main() {
     uint8_t in[64], out[16], k[16];
     int i;
+    bool any_failed;
 #ifndef GETVECTORS
     int fails = 0;
 #endif
@@ -91,6 +93,7 @@ int main() {
             if (memcmp(out, v + (i * len), len)) {
                 printf("fail for %d bytes\n", i);
                 fails++;
+                any_failed = true;
             }
 #endif
         }
@@ -105,5 +108,5 @@ int main() {
 #endif
     }
 
-    return 0;
+    return any_failed;
 }

--- a/test.c
+++ b/test.c
@@ -47,7 +47,7 @@ size_t lengths[4] = {8, 16, 4, 8};
 int siphash_test() {
     uint8_t in[64], out[16], k[16];
     int i;
-    bool any_failed;
+    bool any_failed = false;
 #ifndef GETVECTORS
     int fails = 0;
 #endif


### PR DESCRIPTION
This allows for shell scripts to check for success or failure without parsing
the printed output.  If the function name is later changed from main() it
will also allow other code calling the tests to also easily check the pass
or fail status.