### PR TITLE
Added some common IDE folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 *.exe
 *.out
 *.app
+
+# IDE Folders
+/.code/
+/.idea/
+/.vs/


### PR DESCRIPTION
This is a pretty minimal pull request that simply modifies the `.gitignore` file, adding the Visual Studio, Visual Studio Code, and CLion IDE folders to the list of directories for git to ignore.