### PR TITLE
Rename `DEBUG` to `DEBUG_SIPHASH`

### DIFF
--- a/halfsiphash.c
+++ b/halfsiphash.c
@@ -56,7 +56,7 @@
         v2 = ROTL(v2, 16);                                                     \
     } while (0)
 
-#ifdef DEBUG
+#ifdef DEBUG_SIPHASH
 #define TRACE                                                                  \
     do {                                                                       \
         printf("(%3zu) v0 %08" PRIx32 "\n", inlen, v0);                        \

--- a/siphash.c
+++ b/siphash.c
@@ -64,7 +64,7 @@
         v2 = ROTL(v2, 32);                                                     \
     } while (0)
 
-#ifdef DEBUG
+#ifdef DEBUG_SIPHASH
 #define TRACE                                                                  \
     do {                                                                       \
         printf("(%3zu) v0 %016" PRIx64 "\n", inlen, v0);                       \


### PR DESCRIPTION
`DEBUG` is IMHO too generic a name to use for a flag that causes SipHash to log to the console on every hash operation; changed it to `DEBUG_SIPHASH`.

An example: Xcode's project templates have a `-DDEBUG=1` Clang flag in the 'Debug' config, so literally nearly every iOS and macOS app defines `DEBUG` in dev builds! When I added SipHash to my Mac project, I started getting huge amounts of console logs until I found and renamed its `#ifdef DEBUG`.

(Maybe `TRACE` should be renamed `TRACE_SIPHASH` too? I didn't have a conflict with it, but it is similarly generic.)