### PR TITLE
Make functions return-type void

### DIFF
--- a/halfsiphash.c
+++ b/halfsiphash.c
@@ -79,8 +79,8 @@
     *out: pointer to output data (write-only), outlen bytes must be allocated
     outlen: length of the output in bytes, must be 4 or 8
 */
-int halfsiphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
-                const size_t outlen) {
+void halfsiphash(const void *in, const size_t inlen, const void *k,
+                 uint8_t *out, const size_t outlen) {
 
     const unsigned char *ni = (const unsigned char *)in;
     const unsigned char *kk = (const unsigned char *)k;
@@ -151,7 +151,7 @@ int halfsiphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
     U32TO8_LE(out, b);
 
     if (outlen == 4)
-        return 0;
+        return;
 
     v1 ^= 0xdd;
 
@@ -161,6 +161,4 @@ int halfsiphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
 
     b = v1 ^ v3;
     U32TO8_LE(out + 4, b);
-
-    return 0;
 }

--- a/halfsiphash.h
+++ b/halfsiphash.h
@@ -18,5 +18,5 @@
 #include <inttypes.h>
 #include <string.h>
 
-int halfsiphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
-                const size_t outlen);
+void halfsiphash(const void *in, const size_t inlen, const void *k,
+                 uint8_t *out, const size_t outlen);

--- a/siphash.c
+++ b/siphash.c
@@ -86,8 +86,8 @@
     *out: pointer to output data (write-only), outlen bytes must be allocated
     outlen: length of the output in bytes, must be 8 or 16
 */
-int siphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
-            const size_t outlen) {
+void siphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
+             const size_t outlen) {
 
     const unsigned char *ni = (const unsigned char *)in;
     const unsigned char *kk = (const unsigned char *)k;
@@ -170,7 +170,7 @@ int siphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
     U64TO8_LE(out, b);
 
     if (outlen == 8)
-        return 0;
+        return;
 
     v1 ^= 0xdd;
 
@@ -180,6 +180,4 @@ int siphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
 
     b = v0 ^ v1 ^ v2 ^ v3;
     U64TO8_LE(out + 8, b);
-
-    return 0;
 }

--- a/siphash.h
+++ b/siphash.h
@@ -18,5 +18,5 @@
 #include <inttypes.h>
 #include <string.h>
 
-int siphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
-            const size_t outlen);
+void siphash(const void *in, const size_t inlen, const void *k, uint8_t *out,
+             const size_t outlen);


### PR DESCRIPTION
This produces a small code reduction of a couple of bytes on x86_64.